### PR TITLE
fix: add missing document types for insurance and license_renewal orders

### DIFF
--- a/database/seeders/OrderDocumentTypeSeeder.php
+++ b/database/seeders/OrderDocumentTypeSeeder.php
@@ -140,6 +140,66 @@ class OrderDocumentTypeSeeder extends Seeder
                 'is_required' => false,
                 'sort_order' => 5,
             ],
+            
+            // Insurance Documents
+            [
+                'order_type' => 'insurance',
+                'document_name' => 'Insurance Certificate',
+                'document_key' => 'insurance_certificate',
+                'is_required' => true,
+                'sort_order' => 1,
+            ],
+            [
+                'order_type' => 'insurance',
+                'document_name' => 'Vehicle Registration',
+                'document_key' => 'vehicle_registration',
+                'is_required' => true,
+                'sort_order' => 2,
+            ],
+            [
+                'order_type' => 'insurance',
+                'document_name' => 'Valid ID Card',
+                'document_key' => 'valid_id_card',
+                'is_required' => true,
+                'sort_order' => 3,
+            ],
+            [
+                'order_type' => 'insurance',
+                'document_name' => 'Driver\'s License',
+                'document_key' => 'drivers_license',
+                'is_required' => true,
+                'sort_order' => 4,
+            ],
+            
+            // License Renewal Documents
+            [
+                'order_type' => 'license_renewal',
+                'document_name' => 'Old License',
+                'document_key' => 'old_license',
+                'is_required' => true,
+                'sort_order' => 1,
+            ],
+            [
+                'order_type' => 'license_renewal',
+                'document_name' => 'Insurance Certificate',
+                'document_key' => 'insurance_certificate',
+                'is_required' => true,
+                'sort_order' => 2,
+            ],
+            [
+                'order_type' => 'license_renewal',
+                'document_name' => 'Vehicle Registration',
+                'document_key' => 'vehicle_registration',
+                'is_required' => true,
+                'sort_order' => 3,
+            ],
+            [
+                'order_type' => 'license_renewal',
+                'document_name' => 'Valid ID Card',
+                'document_key' => 'valid_id_card',
+                'is_required' => true,
+                'sort_order' => 4,
+            ],
         ];
 
         foreach ($documentTypes as $type) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -106,6 +106,7 @@ Route::post('/verify-login-otp', [AuthController::class, 'verifyLoginOTP']);
             Route::post('/paystack/verify/{reference}', [PaystackPaymentController::class, 'verifyPayment']);
             
             // Common payment routes
+            Route::post('/check-existing', [PaymentController::class, 'checkExistingPayments']);
             Route::get('/car-receipt/{car_slug}', [PaymentController::class, 'getCarPaymentReceipt']);
             Route::get('/receipt/{payment_slug}', [PaymentController::class, 'getPaymentReceipt']);
             Route::get('/wallet', [PaymentController::class, 'getWalletInfo']);
@@ -326,6 +327,7 @@ Route::middleware(['cors', 'auth:sanctum', 'admin'])->prefix('admin')->group(fun
     Route::get('/document-types', [OrderDocumentController::class, 'getDocumentTypes']);
     Route::post('/orders/{orderSlug}/documents', [OrderDocumentController::class, 'uploadDocuments']);
     Route::post('/orders/{orderSlug}/send-documents', [OrderDocumentController::class, 'sendDocumentsToUser']);
+    Route::post('/orders/{orderSlug}/complete', [OrderDocumentController::class, 'markOrderCompleted']);
     Route::get('/orders/{orderSlug}/documents', [OrderDocumentController::class, 'getOrderDocuments']);
     Route::get('/orders/{orderSlug}/documents/{documentId}', [OrderDocumentController::class, 'viewDocument']);
     


### PR DESCRIPTION
- document types issues
- Implement bulk payments with duplicate prevention  
- Add automatic payment verification and order creation
- Update payment receipt design and reminder status flow
- Update OrderDocumentTypeSeeder with comprehensive document types
- Fix dropdown showing 0 options on live domain